### PR TITLE
fix(Utils) handle no displayName or name for components

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from "react"
 
 
 export const nameWithContext = (Lower, prop = "name") => {
-  const getDisplayName = (Lower) => ((Lower.displayName || Lower.name).replace(/Tag$/, ""))
+  const getDisplayName = (Lower) => ((Lower.displayName || Lower.name || "Component").replace(/Tag$/, ""))
 
   const buildInputName = (namespaces, name = "") => (
     [ ...namespaces, name ].map((field, index) => ( index === 0 ? field : `[${field}]` )).join("")


### PR DESCRIPTION
Internet explorer doesn't support `Function.prototype.name`, which
causes `src/utils.js` to throw errors when trying to get a display name.
To fix this, we take inspiration from
[react-redux](https://github.com/reactjs/react-redux/blob/master/src/components/connect.js#L19)
and use an empty string as the third option in our or clause.

Fix #1
