### PR TITLE
Remove document csrf query

### DIFF
--- a/src/forms.jsx
+++ b/src/forms.jsx
@@ -31,7 +31,7 @@ export const FormTag = React.createClass({
 
     return (
       <form
-        {...whitelistProps(this.props, "url", "children")}
+        {...whitelistProps(this.props, "url", "children", "csrfToken")}
         acceptCharset="UTF-8"
         action={this.props.url}
         method={browserHTTPMethod}
@@ -42,7 +42,7 @@ export const FormTag = React.createClass({
             value={fakedHTTPMethod}
             />
         )}
-        {this.props.csrfToken && (
+        {csrfToken && (
           <HiddenFieldTag
             name="authenticity_token"
             value={csrfToken.content}

--- a/src/forms.jsx
+++ b/src/forms.jsx
@@ -6,6 +6,7 @@ export const FormTag = React.createClass({
   propTypes: {
     url: PropTypes.string.isRequired,
     method: PropTypes.oneOf([ "get", "post", "put", "patch", "delete" ]),
+    csrfToken: PropTypes.string,
     children: PropTypes.node,
   },
 
@@ -25,7 +26,8 @@ export const FormTag = React.createClass({
       fakedHTTPMethod = this.props.method
     }
 
-    const csrfToken = document.querySelector("head meta[name='csrf-token']")
+    const csrfToken = this.props.csrfToken ||
+      document.querySelector("head meta[name='csrf-token']")
 
     return (
       <form
@@ -40,7 +42,7 @@ export const FormTag = React.createClass({
             value={fakedHTTPMethod}
             />
         )}
-        {csrfToken && (
+        {this.props.csrfToken && (
           <HiddenFieldTag
             name="authenticity_token"
             value={csrfToken.content}

--- a/src/forms.jsx
+++ b/src/forms.jsx
@@ -27,7 +27,7 @@ export const FormTag = React.createClass({
     }
 
     const csrfToken = this.props.csrfToken ||
-      document.querySelector("head meta[name='csrf-token']")
+      document.querySelector("head meta[name='csrf-token']").content
 
     return (
       <form
@@ -45,7 +45,7 @@ export const FormTag = React.createClass({
         {csrfToken && (
           <HiddenFieldTag
             name="authenticity_token"
-            value={csrfToken.content}
+            value={csrfToken}
             />
         )}
         <HiddenFieldTag


### PR DESCRIPTION
@danott allows for Rails' CSRF token to be passed into the `FormTag` via props and falls back to using the original `document.querySelector("head meta[name='csrf-token']")` method.

Useful if you want to server render any forms using this lib and the document is not available.
