### PR TITLE
feat(FieldsFor) allow use outside of `FormFor`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ It provides the Rails context for generating `input[name]` by using it's own `na
 The `FieldsFor` component pushes a name onto the Rails naming context.
 That's it.
 
+`FieldsFor` can be used in place of a `FormFor` if you want to generate the form tag in rails and only render part of the form body using React.
+
 `FieldsFor` is aliased as `HashFields` and `ArrayFields` for expressing intent.
 
 ### Example

--- a/src/forms.jsx
+++ b/src/forms.jsx
@@ -111,7 +111,7 @@ export const FieldsFor = React.createClass({
   getChildContext() {
     return {
       railsFormNamespaces: [
-        ...this.context.railsFormNamespaces,
+        ...(this.context.railsFormNamespaces || []),
         this.props.name,
       ],
     }


### PR DESCRIPTION
I have a use case where I want to build my form tag and part of my form using native rails helpers, and then part of my form using React. To accomplish this, I've made it so `FieldsFor` can work properly even if `this.context.railsFormNamespaces` is null.

Previously, it would throw an error because you can't splat `null` into an array