### PR TITLE
Fixes exception for missing react import

### DIFF
--- a/src/tags.jsx
+++ b/src/tags.jsx
@@ -1,4 +1,5 @@
 import { whitelistProps } from "./utils"
+import React from "react"
 
 export const CheckBoxTag = ({
   checkedValue = 1,


### PR DESCRIPTION
By importing React in tags.jsx, this issue is fixed:
```javascript
 React::ServerRendering::PrerenderError:
   Encountered error "#<ExecJS::ProgramError: ReferenceError: React is not defined>" when prerendering <component-name> with {}
   HiddenFieldTag ((execjs):588:3)
```