### PR TITLE
Align `CheckBoxTag` wrapping with Rails

### DIFF
--- a/src/tags.jsx
+++ b/src/tags.jsx
@@ -7,10 +7,10 @@ export const CheckBoxTag = ({
   ...props
 }) => {
   return (
-    <span>
+    <React.Fragment>
       <HiddenFieldTag name={props.name} value={uncheckedValue} />
       <input type="checkbox" value={checkedValue} {...props} />
-    </span>
+    </React.Fragment>
   )
 }
 


### PR DESCRIPTION
The `check_box` method doesn't wrap the `input`s in a span. This can cause issues when using `label`s as custom checkboxes using CSS as the structuring of the DOM is important.