### PR TITLE
Changed enclosing span tag to React fragment

### DIFF
--- a/src/forms.jsx
+++ b/src/forms.jsx
@@ -100,7 +100,7 @@ export class FieldsFor extends React.Component {
   }
 
   render() {
-    return <span>{this.props.children}</span>
+    return <React.fragment>{this.props.children}</React.fragment>
   }
 }
 


### PR DESCRIPTION
Since the FieldsFor function just provides context to its children, it seems better to avoid rendering out extra enclosing HTML. 

In my use case, the extra span tags that were added were causing some issues with my CSS selectors. This solved that issue for me. 

Thanks for these great helpers!