### PR TITLE
Corrected typo for React Fragment

### DIFF
--- a/src/forms.jsx
+++ b/src/forms.jsx
@@ -100,7 +100,7 @@ export class FieldsFor extends React.Component {
   }
 
   render() {
-    return <React.fragment>{this.props.children}</React.fragment>
+    return <React.Fragment>{this.props.children}</React.Fragment>
   }
 }
 


### PR DESCRIPTION
I had been getting errors of the form "Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined".

It seems like there is a typo on the component name; only the capitalized version is valid.